### PR TITLE
Fix content type so HTML renders correctly

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -23,12 +23,16 @@ mod page;
 use page::*;
 use colorhsl::*;
 
+use rocket::response::content;
+
+type Html = content::Html<String>;
+
 fn sort_list(v: &Vec<ColorHsl>) -> Vec<ColorHsl> {
     Vec::new()
 }
 
 #[get("/")]
-fn index() -> String {
+fn index() -> Html {
     let params = Page::default();
     let mut output = String::new();
     let list: Vec<ColorHsl> = vec![
@@ -48,11 +52,11 @@ fn index() -> String {
     output.push_str(&form(&params));
     output.push_str(&body(&list));
     output.push_str(&footer());
-    output
+    content::Html(output)
 }
 
 #[post("/", data = "<params>")]
-fn findex(params: Page) -> String {
+fn findex(params: Page) -> Html {
     let mut output = String::new();
     let list: Vec<ColorHsl> = vec![
         ColorHsl::from_hex("#65d1fa", "#65d1fa").unwrap(),
@@ -71,7 +75,7 @@ fn findex(params: Page) -> String {
     output.push_str(&form(&params));
     output.push_str(&body(&list));
     output.push_str(&footer());
-    output
+    content::Html(output)
 }
 
 


### PR DESCRIPTION
If you return `String`, Rocket will set the content type to `text/plain`, and HTML won't render. This updates routes to correctly set the content type before sending the response.